### PR TITLE
Add custom processing for RHACS images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 # Binaries
-cve-analyser
-
+./cve-analyser

--- a/cmd/cve-analyser/main.go
+++ b/cmd/cve-analyser/main.go
@@ -228,7 +228,7 @@ func main() {
 	var CPEtoRepos helper.RepoToCPEmap = helper.CallRepoToCPE()
 
 	// initiate 10 threads
-	for w := 0; w < 10; w++ {
+	for w := 0; w < 1; w++ {
 		wg.Add(1)
 		go processLines(&wg, jobs, results, CPEtoRepos)
 	}

--- a/cmd/cve-analyser/main.go
+++ b/cmd/cve-analyser/main.go
@@ -204,9 +204,7 @@ func main() {
 		os.Exit(1)
 	}
 	file_name := os.Args[1]
-	if fileExist(file_name) {
-		fmt.Printf("Processing the \"%v\"...\n", file_name)
-	} else {
+	if !fileExist(file_name) {
 		fmt.Println("file to check is incorrect or not exist")
 		os.Exit(1)
 	}

--- a/pkg/pyxis_api.go
+++ b/pkg/pyxis_api.go
@@ -55,9 +55,31 @@ func unique(s []string) []string {
 	return result
 }
 
+func repomap(repository string, name string) string {
+	var result string
+	switch {
+	case repository == "rh-acs":
+		result += "advanced-cluster-security/"
+		switch{
+		case name == "main":
+			result += "rhacs-main-rhel8"
+		case name == "collector":
+			result += "rhacs-collector-rhel8"
+		case name == "scanner":
+			result += "rhacs-scanner-rhel8"
+		case name == "scanner-db":
+			result += "rhacs-scanner-db-rhel8"
+		}
+	default:
+		result += repository + "/" + name
+	}
+	return result
+}
+
 func CallPyxis_CPE(repository string, name string, tag string, CPEtoRepos RepoToCPEmap) []string {
 	var AllCPEs []string
-	url := PyxisUrl + "/repositories/registry/registry.access.redhat.com/repository/" + repository + "/" + name + "/tag/" + tag
+
+	url := PyxisUrl + "/repositories/registry/registry.access.redhat.com/repository/" + repomap(repository, name) + "/tag/" + tag
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -146,8 +168,10 @@ func CallRepoToCPE() RepoToCPEmap {
 }
 
 func CallPyxis_ImageID(repository string, name string, tag string) string {
-	url := PyxisUrl + "/repositories/registry/registry.access.redhat.com/repository/" + repository + "/" + name + "/tag/" + tag
+
+	url := PyxisUrl + "/repositories/registry/registry.access.redhat.com/repository/" + repomap(repository, name) + "/tag/" + tag
 	//fmt.Println(url)
+
 	// Get request
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
The Red Hat Advanced Cluster Security container images have not always been where they are now in the registry. Today they are under "/advanced-cluster-security" but in earlier releases the images where under "/rh-acs"

When users of the cve-analyser try to process for example "/rh-acs/main" the tool will report "Not Found Any Information"
This is because the images have moved and so the lookups fail. By mapping the old image locations to their new locations, the cve-analyser can properly determine the CVE results.

I'm not aware of another way to solve this issue.